### PR TITLE
Add QCOM targert-specific cong & helper macros

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -616,4 +616,7 @@ RS_PREBUILT_CLCORE := prebuilts/sdk/renderscript/lib/$(TARGET_ARCH)/librsrt_$(TA
 RS_PREBUILT_LIBPATH := -L prebuilts/ndk/8/platforms/android-9/arch-$(TARGET_ARCH)/usr/lib
 RS_PREBUILT_COMPILER_RT := prebuilts/sdk/renderscript/lib/$(TARGET_ARCH)/libcompiler_rt.a
 
+# Rules for QCOM targets
+include $(BUILD_SYSTEM)/qcom_target.mk
+
 include $(BUILD_SYSTEM)/dumpvar.mk

--- a/core/main.mk
+++ b/core/main.mk
@@ -259,6 +259,9 @@ endif
 # Bring in standard build system definitions.
 include $(BUILD_SYSTEM)/definitions.mk
 
+# Bring in Qualcomm helper macros
+include $(BUILD_SYSTEM)/qcom_utils.mk
+
 # Bring in dex_preopt.mk
 include $(BUILD_SYSTEM)/dex_preopt.mk
 

--- a/core/pathmap.mk
+++ b/core/pathmap.mk
@@ -63,6 +63,36 @@ define include-path-for
 $(foreach n,$(1),$(patsubst $(n):%,%,$(filter $(n):%,$(pathmap_INCL))))
 endef
 
+# Enter project path into pathmap
+#
+# $(1): name
+# $(2): path
+#
+define project-set-path
+$(eval pathmap_PROJ += $(1):$(2))
+endef
+
+# Enter variant project path into pathmap
+#
+# $(1): name
+# $(2): variable to check
+# $(3): base path
+#
+define project-set-path-variant
+    $(call project-set-path,$(1),$(strip \
+        $(if $($(2)), \
+            $(3)-$($(2)), \
+            $(3))))
+endef
+
+# Returns the path to the requested module's include directory,
+# relative to the root of the source tree.
+#
+# $(1): a list of modules (or other named entities) to find the projects for
+define project-path-for
+$(foreach n,$(1),$(patsubst $(n):%,%,$(filter $(n):%,$(pathmap_PROJ))))
+endef
+
 #
 # Many modules expect to be able to say "#include <jni.h>",
 # so make it easy for them to find the correct path.

--- a/core/qcom_target.mk
+++ b/core/qcom_target.mk
@@ -1,0 +1,43 @@
+# Target-specific configuration
+
+# Populate the qcom hardware variants in the project pathmap.
+define qcom-set-path-variant
+$(call project-set-path-variant,qcom-$(2),TARGET_QCOM_$(1)_VARIANT,hardware/qcom/$(2))
+endef
+
+ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
+
+    qcom_flags := -DQCOM_HARDWARE
+    qcom_flags += -DQCOM_BSP
+
+    TARGET_USES_QCOM_BSP := true
+    TARGET_ENABLE_QC_AV_ENHANCEMENTS := true
+
+    # Enable DirectTrack for legacy targets
+    ifneq ($(filter msm7x30 msm8660 msm8960,$(TARGET_BOARD_PLATFORM)),)
+        ifeq ($(BOARD_USES_LEGACY_ALSA_AUDIO),true)
+            qcom_flags += -DQCOM_DIRECTTRACK
+        endif
+        # Enable legacy graphics functions
+        qcom_flags += -DQCOM_BSP_LEGACY
+    endif
+
+    TARGET_GLOBAL_CFLAGS += $(qcom_flags)
+    TARGET_GLOBAL_CPPFLAGS += $(qcom_flags)
+    CLANG_TARGET_GLOBAL_CFLAGS += $(qcom_flags)
+    CLANG_TARGET_GLOBAL_CPPFLAGS += $(qcom_flags)
+
+$(call project-set-path,qcom-audio,hardware/qcom/audio-caf/$(TARGET_BOARD_PLATFORM))
+$(call qcom-set-path-variant,CAMERA,camera)
+$(call project-set-path,qcom-display,hardware/qcom/display-caf/$(TARGET_BOARD_PLATFORM))
+$(call qcom-set-path-variant,GPS,gps)
+$(call project-set-path,qcom-media,hardware/qcom/media-caf/$(TARGET_BOARD_PLATFORM))
+$(call qcom-set-path-variant,SENSORS,sensors)
+else
+$(call project-set-path,qcom-audio,hardware/qcom/audio/default)
+$(call qcom-set-path-variant,CAMERA,camera)
+$(call project-set-path,qcom-display,hardware/qcom/display/$(TARGET_BOARD_PLATFORM))
+$(call qcom-set-path-variant,GPS,gps)
+$(call project-set-path,qcom-media,hardware/qcom/media/default)
+$(call qcom-set-path-variant,SENSORS,sensors)
+endif

--- a/core/qcom_utils.mk
+++ b/core/qcom_utils.mk
@@ -1,0 +1,222 @@
+# Board platforms lists to be used for
+# TARGET_BOARD_PLATFORM specific featurization
+QCOM_BOARD_PLATFORMS += msm7x30
+QCOM_BOARD_PLATFORMS += msm8226
+QCOM_BOARD_PLATFORMS += msm8610
+QCOM_BOARD_PLATFORMS += msm8660
+QCOM_BOARD_PLATFORMS += msm8916
+QCOM_BOARD_PLATFORMS += msm8960
+QCOM_BOARD_PLATFORMS += msm8974
+QCOM_BOARD_PLATFORMS += mpq8092
+QCOM_BOARD_PLATFORMS += msm_bronze
+QCOM_BOARD_PLATFORMS += apq8084
+
+MSM7K_BOARD_PLATFORMS := msm7x30
+MSM7K_BOARD_PLATFORMS += msm7x27
+MSM7K_BOARD_PLATFORMS += msm7x27a
+MSM7K_BOARD_PLATFORMS += msm7k
+
+QSD8K_BOARD_PLATFORMS := qsd8k
+
+
+# vars for use by utils
+empty :=
+space := $(empty) $(empty)
+colon := $(empty):$(empty)
+underscore := $(empty)_$(empty)
+
+# $(call match-word,w1,w2)
+# checks if w1 == w2
+# How it works
+#   if (w1-w2 not empty or w2-w1 not empty) then not_match else match
+#
+# returns true or empty
+#$(warning :$(1): :$(2): :$(subst $(1),,$(2)):) \
+#$(warning :$(2): :$(1): :$(subst $(2),,$(1)):) \
+#
+define match-word
+$(strip \
+  $(if $(or $(subst $(1),$(empty),$(2)),$(subst $(2),$(empty),$(1))),,true) \
+)
+endef
+
+# $(call find-word-in-list,w,wlist)
+# finds an exact match of word w in word list wlist
+#
+# How it works
+#   fill wlist spaces with colon
+#   wrap w with colon
+#   search word w in list wl, if found match m, return stripped word w
+#
+# returns stripped word or empty
+define find-word-in-list
+$(strip \
+  $(eval wl:= $(colon)$(subst $(space),$(colon),$(strip $(2)))$(colon)) \
+  $(eval w:= $(colon)$(strip $(1))$(colon)) \
+  $(eval m:= $(findstring $(w),$(wl))) \
+  $(if $(m),$(1),) \
+)
+endef
+
+# $(call match-word-in-list,w,wlist)
+# does an exact match of word w in word list wlist
+# How it works
+#   if the input word is not empty
+#     return output of an exact match of word w in wordlist wlist
+#   else
+#     return empty
+# returns true or empty
+define match-word-in-list
+$(strip \
+  $(if $(strip $(1)), \
+    $(call match-word,$(call find-word-in-list,$(1),$(2)),$(strip $(1))), \
+  ) \
+)
+endef
+
+# $(call match-prefix,p,delim,w/wlist)
+# matches prefix p in wlist using delimiter delim
+#
+# How it works
+#   trim the words in wlist w
+#   if find-word-in-list returns not empty
+#     return true
+#   else
+#     return empty
+#
+define match-prefix
+$(strip \
+  $(eval w := $(strip $(1)$(strip $(2)))) \
+  $(eval text := $(patsubst $(w)%,$(1),$(3))) \
+  $(if $(call match-word-in-list,$(1),$(text)),true,) \
+)
+endef
+
+# ----
+# The following utilities are meant for board platform specific
+# featurisation
+
+# $(call get-vendor-board-platforms,v)
+# returns list of board platforms for vendor v
+define get-vendor-board-platforms
+$(if $(call match-word,$(BOARD_USES_$(1)_HARDWARE),true),$($(1)_BOARD_PLATFORMS))
+endef
+
+# $(call is-board-platform,bp)
+# returns true or empty
+define is-board-platform
+$(call match-word,$(1),$(TARGET_BOARD_PLATFORM))
+endef
+
+# $(call is-not-board-platform,bp)
+# returns true or empty
+define is-not-board-platform
+$(if $(call match-word,$(1),$(TARGET_BOARD_PLATFORM)),,true)
+endef
+
+# $(call is-board-platform-in-list,bpl)
+# returns true or empty
+define is-board-platform-in-list
+$(call match-word-in-list,$(TARGET_BOARD_PLATFORM),$(1))
+endef
+
+# $(call is-vendor-board-platform,vendor)
+# returns true or empty
+define is-vendor-board-platform
+$(strip \
+  $(call match-word-in-list,$(TARGET_BOARD_PLATFORM),\
+    $(call get-vendor-board-platforms,$(1)) \
+  ) \
+)
+endef
+
+# $(call is-chipset-in-board-platform,chipset)
+# does a prefix match of chipset in TARGET_BOARD_PLATFORM
+# uses underscore as a delimiter
+#
+# returns true or empty
+define is-chipset-in-board-platform
+$(call match-prefix,$(1),$(underscore),$(TARGET_BOARD_PLATFORM))
+endef
+
+# $(call is-chipset-prefix-in-board-platform,prefix)
+# does a chipset prefix match in TARGET_BOARD_PLATFORM
+# assumes '_' and 'a' as the delimiter to the chipset prefix
+#
+# How it works
+#   if ($(prefix)_ or $(prefix)a match in board platform)
+#     return true
+#   else
+#     return empty
+#
+define is-chipset-prefix-in-board-platform
+$(strip \
+  $(eval delim_a := $(empty)a$(empty)) \
+  $(if \
+    $(or \
+      $(call match-prefix,$(1),$(delim_a),$(TARGET_BOARD_PLATFORM)), \
+      $(call match-prefix,$(1),$(underscore),$(TARGET_BOARD_PLATFORM)), \
+    ), \
+    true, \
+  ) \
+)
+endef
+
+#----
+# The following utilities are meant for Android Code Name
+# specific featurisation
+#
+# refer http://source.android.com/source/build-numbers.html
+# for code names and associated sdk versions
+CUPCAKE_SDK_VERSIONS := 3
+DONUT_SDK_VERSIONS   := 4
+ECLAIR_SDK_VERSIONS  := 5 6 7
+FROYO_SDK_VERSIONS   := 8
+GINGERBREAD_SDK_VERSIONS := 9 10
+HONEYCOMB_SDK_VERSIONS := 11 12 13
+ICECREAM_SANDWICH_SDK_VERSIONS := 14 15
+JELLY_BEAN_SDK_VERSIONS := 16 17 18
+
+# $(call is-platform-sdk-version-at-least,version)
+# version is a numeric SDK_VERSION defined above
+define is-platform-sdk-version-at-least
+$(strip \
+  $(if $(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= $(1) ))" )), \
+    true, \
+  ) \
+)
+endef
+
+# $(call is-android-codename,codename)
+# codename is one of cupcake,donut,eclair,froyo,gingerbread,icecream
+# please refer the $(codename)_SDK_VERSIONS declared above
+define is-android-codename
+$(strip \
+  $(if \
+    $(call match-word-in-list,$(PLATFORM_SDK_VERSION),$($(1)_SDK_VERSIONS)), \
+    true, \
+  ) \
+)
+endef
+
+# $(call is-android-codename-in-list,cnlist)
+# cnlist is combination/list of android codenames
+define is-android-codename-in-list
+$(strip \
+  $(eval acn := $(empty)) \
+    $(foreach \
+      i,$(1),\
+      $(eval acn += \
+        $(if \
+          $(call \
+            match-word-in-list,\
+            $(PLATFORM_SDK_VERSION),\
+            $($(i)_SDK_VERSIONS)\
+          ),\
+          true,\
+        )\
+      )\
+    ) \
+  $(if $(strip $(acn)),true,) \
+)
+endef


### PR DESCRIPTION
special thanks to @beanstown106

History
===

[*] qcom_utils: Make "is-vendor-board-platform,XX" depend on BOARD_HAS_XX_HARDWARE

Prevent qc's code from wrongly kicking in for AOSP-derived
configurations

Change-Id: If53c5136f780fc7bc295469a9552925f8b1a3a94

[*] qcom_utils: Update list of QCOM_BOARD_PLATFORMS

Add msm8226 (Moto G) and other upcoming platforms
Change-Id: Icf895cbcf86791ca800636a1c0893b3a905a27a0

[*] build: Add board platforms to qcom_utils

Change-Id: I85458167bf2b9c04b029d09b87bf791ff4cfd04d

[*] build: Use common name for QCOM 7K boards.

This is needed to build QCOM HAL without external modifications. The
device would now have to specify msm7x27 or msm7x30 instead of
specifying the full name.

Patch Set 2: Add msm7x27a into the list.

Change-Id: I25018e397b5aad27fab5244731a574ae86752e17

[*] Add new version to qcom_utils.mk

Change-Id: I1ca1532fd4968450715ecd0cca7729e0e6d507ef

[*] Build: update qcom_utils.mk

[*] Add build macro to determine Android Release

[*] Adding platform sdk version 18 for JB MR2.

Change-Id: I79aa831ddd335bd14bd777506c210acc5d9960f1

[*] build: Remove unused qcom CFLAG

Change-Id: I6ead3e57899bcb007d4d284901f918a65a9e6926

[*] build: Add QCOM flags to Clang CFLAGS

Change-Id: I56f0d4106f5d3d27c1ace744d30c1c81f0052bbd

[*] build: Clean up QCOM flag definitions

Change-Id: I66bca2db83260ccd65b82e540ee9f7961f00b030

[*] Fix QCOM_BSP_LEGACY

Checks in the Android.mk files do not active the cflags for .h
files, causing a build that crashes constantly.

Change-Id: I315c760488445629fda860ba70066417c7d68b8b

[*] build: Fix QCOM_BSP_LEGACY cflags

Change-Id: I880f32892d9e082e3ba92878414f3cb3c6f08066

[*] Enable QCOM_BSP_LEGACY flag for pre-8974 targets

Change-Id: I895f1b1cbad0d260e1bca87ccb61e6194de023fd

[*] pathmap: Point QC HAL pathmaps directly to the source

Directly map to the actual HAL directory, including the
board platform. This lets project-path-for point directly
to the respective HALs.

Change-Id: Ic4ed61bbdea9d0b5683502bf84a8410e76858527

[*] build: Enable QCOM_BSP, QC_AV with QCOM_HARDWARE

Change-Id: Ibf9dd35272521109fea52e46bacf6e1e3074ed6a

[*] build: Automatically set QCOM audio, display, media variants

* Device platform should determing the HAL that ought to be used. This
  commit forces QCOM_HARDWARE to select the -caf HAL variants, which
  are then broken down by platform within the variant path.

Change-Id: I6fc7a3def7b93112f034a3b89552f302727cdbf8

[*] build: qcom: Set QCOM_*_PATH variables for hardware/qcom-* projects

This consolidates a bunch of one-off logic scattered throughout the
code base.  Usage in Android.mk files is trivial:

At top level, use e.g. "ifeq ($(call my-dir),$(QCOM_AUDIO_PATH))".
This works for all variants, including non-variants (i.e. AOSP).

Within subdirs, use e.g. hardware/qcom/audio => $(QCOM_AUDIO_PATH)

Change-Id: Iee2497ea9a7efeb4ae9e861b84c532b19da7b69d

[*] build: Introduce project pathmap and use it for qcom variants

The project pathmap tracks the path to the top level of a project.  The
following functions are provided:

 * project-set-path adds an entry.
 * project-set-path-variant adds a "variant" entry.
 * project-path-for retrieves an entry.

To use as a guard in Android.mk:

  ifeq ($(call my-dir),$(call project-path-for,projectname))

To use for include paths in Android.mk:

  LOCAL_C_INCLUDES += $(call project-path-for,projectname)/...

Set project pathmap for qcom project variants.

Change-Id: I8dceca72a1ba80fc7b1830c5ab285d444f530457

[*] build: Set QCOM variants for non-QCOM_HARDWARE defined targets

* Nexus devices and others typically do not define the QCOM_HARDWARE
  flag, so the variant path should always default to the AOSP variant.
* Unconditionally set the variant to the AOSP HAL by default.

Change-Id: I714170897128f92718af266366cfcbf3136e8981

[*] build: Fix cflags for QC targets

Change-Id: I2281bec3afb4d80e80845718d880dc24ef7baf32

[*] build: Add Qualcomm's helper macros

 * This is used everywhere in Qualcomm's code. There's no reason we need
   to constantly replace it with uglier stuff in our Makefiles.

Change-Id: I0183a338470ec96a38f356a47bae65a0d3fb2c95

[*] build: Add QCOM target-specific config

 * Needed to support global DirectTract config on legacy targets
 * Let's also eliminate some boilerplate

Change-Id: I736c10a5e7e1f3d1e0de9e60f29b60add276f151